### PR TITLE
Adjust config names/inputs to reduce confusion. 

### DIFF
--- a/klippy/extras/hx711.py
+++ b/klippy/extras/hx711.py
@@ -73,7 +73,7 @@ class PrinterHx711:
         self.mcu = dout_pin_params['chip']
         self.gain = config.getchoice('gain', {32: 2, 64: 3, 128: 1}, default=64)
         self.sps = config.getchoice('board_freq',{10: 10, 80: 80}, default=10)
-        self.sample_interval = config.getint('sample_interval', default=1)
+        self.sample_interval = config.getfloat('sample_interval', default=1)
         self.comm_delay = config.getint('comm_delay', default=1)
         self.config = config
         ppins.register_chip(self.name, self)

--- a/klippy/extras/hx711.py
+++ b/klippy/extras/hx711.py
@@ -72,7 +72,7 @@ class PrinterHx711:
         self.sck_pin = sck_pin_params['pin']
         self.mcu = dout_pin_params['chip']
         self.gain = config.getchoice('gain', {32: 2, 64: 3, 128: 1}, default=64)
-        self.sps = config.getchoice('sps',{10: 10, 80: 80}, default=10)
+        self.sps = config.getchoice('board_freq',{10: 10, 80: 80}, default=10)
         self.sample_interval = config.getint('sample_interval', default=1)
         self.comm_delay = config.getint('comm_delay', default=1)
         self.config = config

--- a/klippy/extras/hx711.py
+++ b/klippy/extras/hx711.py
@@ -56,7 +56,8 @@ class MCU_hx711:
         if self._callback:
             self._callback(self.mcu.estimated_print_time(self._last_time),
                 self._last_value)
-        logging.info("hx711 value is %d \t%s" % ( self._last_value, bin(self._last_value) ) )
+        logging.info("hx711 value is %d \t%s" % ( self._last_value,
+        bin(self._last_value) ) )
 
 
 

--- a/klippy/extras/weight_scale.py
+++ b/klippy/extras/weight_scale.py
@@ -53,6 +53,8 @@ class WeighScale:
                 logging.error("Please calibrate the scale with" \
                     " two different weights")
                 self.calibrated = False
+            elif (self.calibrate_weight2 == 0):
+                logging.error("Weight 2 must be a non-zero value.")
 
         # if calibration config is ok, calculate calibration vaules
         if self.calibrated:

--- a/src/hx711.c
+++ b/src/hx711.c
@@ -75,7 +75,7 @@ void command_config_hx711(uint32_t *args)
     h->dout = gpio_in_setup(args[1], 1); // enable pullup
     h->sck = gpio_out_setup(args[2], 0); // initialize as low
     h->gain = args[3];
-    h->SAMPLE_INTERVAL = (CONFIG_CLOCK_FREQ/[args[4]]);
+    h->SAMPLE_INTERVAL = (CONFIG_CLOCK_FREQ/args[4]);
     h->COMM_DELAY = timer_from_us(args[5]);
     h->conversion_time = CONFIG_CLOCK_FREQ/args[6];
     h->sample_idx = 0;

--- a/src/hx711.c
+++ b/src/hx711.c
@@ -75,7 +75,7 @@ void command_config_hx711(uint32_t *args)
     h->dout = gpio_in_setup(args[1], 1); // enable pullup
     h->sck = gpio_out_setup(args[2], 0); // initialize as low
     h->gain = args[3];
-    h->SAMPLE_INTERVAL = args[4]*(CONFIG_CLOCK_FREQ/10);
+    h->SAMPLE_INTERVAL = (CONFIG_CLOCK_FREQ/[args[4]]);
     h->COMM_DELAY = timer_from_us(args[5]);
     h->conversion_time = CONFIG_CLOCK_FREQ/args[6];
     h->sample_idx = 0;

--- a/src/hx711.c
+++ b/src/hx711.c
@@ -92,7 +92,7 @@ void command_query_hx711(uint32_t *args)
     struct hx711 *h = oid_lookup(args[0], command_config_hx711);
     sched_del_timer(&h->timer);
     h->timer.func = hx711_event;
-    h->timer.waketime = timer_read_time() + h->conversion_time; 
+    h->timer.waketime = timer_read_time() + h->conversion_time;
     sched_add_timer(&h->timer);
 }
 DECL_COMMAND(command_query_hx711,


### PR DESCRIPTION
- Change sps to board_freq.
- Change sample_interval config input value to reflect samples/second
- Change sample_interval config value to float. 
- Check for zero value on weight2